### PR TITLE
JanusGateway::Error: No message set

### DIFF
--- a/lib/janus_gateway/error.rb
+++ b/lib/janus_gateway/error.rb
@@ -6,6 +6,8 @@ module JanusGateway
     # @param [String] error_info
     def initialize(error_code, error_info)
       @code, @info = error_code, error_info
+
+      super(error_info)
     end
 
     # @return [String]

--- a/lib/janus_gateway/error.rb
+++ b/lib/janus_gateway/error.rb
@@ -7,12 +7,7 @@ module JanusGateway
     def initialize(error_code, error_info)
       @code, @info = error_code, error_info
 
-      super(error_info)
-    end
-
-    # @return [String]
-    def message
-      "<Code: #{code}> <Info: #{info}>"
+      super("<Code: #{code}> <Info: #{info}>")
     end
 
     # @return [Integer]

--- a/lib/janus_gateway/version.rb
+++ b/lib/janus_gateway/version.rb
@@ -1,3 +1,3 @@
 module JanusGateway
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end

--- a/spec/janus/error_spec.rb
+++ b/spec/janus/error_spec.rb
@@ -7,7 +7,7 @@ describe JanusGateway::Error do
   let(:error) { JanusGateway::Error.new(error_code, error_info) }
 
   it 'should convert error to the string' do
-    expect(error.to_s).to eq('test-123')
+    expect(error.to_s).to eq('<Code: 123> <Info: test-123>')
   end
 
 end

--- a/spec/janus/error_spec.rb
+++ b/spec/janus/error_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe JanusGateway::Error do
+
+  let(:error_code) { 123 }
+  let(:error_info) { 'test-123' }
+  let(:error) { JanusGateway::Error.new(error_code, error_info) }
+
+  it 'should convert error to the string' do
+    expect(error.to_s).to eq('test-123')
+  end
+
+end


### PR DESCRIPTION
Error doesn't show message in `to_s`:
```ruby
puts JanusGateway::Error.new(123, 'my info').to_s
```
gives:
```
JanusGateway::Error
```

I think we should set the `message` by calling super constructor?