### PR TITLE
Websocket transport: reject transactions on connection close

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,12 +8,12 @@
 
 # Offense count: 4
 Metrics/AbcSize:
-  Max: 31
+  Max: 35
 
 # Offense count: 9
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 28
+  Max: 30
 
 # Offense count: 6
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/lib/janus_gateway/transport/websocket.rb
+++ b/lib/janus_gateway/transport/websocket.rb
@@ -54,6 +54,11 @@ module JanusGateway
 
       client.on :close do
         emit :close
+
+        @transaction_queue.each do |transaction_id, promise|
+          error = JanusGateway::Error.new(0, "Transaction id `#{transaction_id}` has failed due to websocket `close`!")
+          promise.fail(error).execute
+        end
       end
     end
 
@@ -75,7 +80,7 @@ module JanusGateway
 
       thread = Thread.new do
         sleep(_transaction_timeout)
-        error = JanusGateway::Error.new(0, "Transaction id `#{transaction}` has failed due to timeout!")
+        error = JanusGateway::Error.new(0, "Transaction id `#{transaction}` has failed due to `timeout`!")
         promise.fail(error).execute
       end
 

--- a/lib/janus_gateway/version.rb
+++ b/lib/janus_gateway/version.rb
@@ -1,3 +1,3 @@
 module JanusGateway
-  VERSION = '0.0.7'
+  VERSION = '0.0.8'
 end

--- a/spec/janus/transport/websocket_spec.rb
+++ b/spec/janus/transport/websocket_spec.rb
@@ -91,5 +91,22 @@ describe JanusGateway::Transport::WebSocket do
 
       transport.disconnect
     end
+
+    it 'should remove pending transactions if connections drops' do
+      transport.stub(:_create_client).with(url, protocol).and_return(ws_client)
+      transport.stub(:transaction_id_new).and_return('ABCDEFGHIJK-1', 'ABCDEFGHIJK-2')
+
+      transport.connect
+      promise1 = transport.send_transaction(janus: 'test1')
+      promise2 = transport.send_transaction(janus: 'test2')
+
+      ws_client.emit :close
+
+      expect(promise1.value).to eq(nil)
+      expect(promise1.rejected?).to eq(true)
+
+      expect(promise2.value).to eq(nil)
+      expect(promise2.rejected?).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
First trigger "close", then reject transactions.